### PR TITLE
Deps: Add `remote_pdb` as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pdb
+remote_pdb


### PR DESCRIPTION
Fixes #29
The pip package `remote_pdb` is required for runtime execution so add it
to the `requirements.txt` file.